### PR TITLE
Split Tenets from Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,13 @@
-# Programmer's Oath
-
-**As a programmer, I swear to fulfill these tenets:**
-
-I will only undertake honest and moral work. I will stand firm against any requirement that exploits or harms people.
-
-I will respect the learnings of those programmers who came before me, and share my learnings with those to come.
-
-I will remember that programming is art as well as science, and that warmth, empathy and understanding may outweigh a clever algorithm or technical argument.
-
-I will not be ashamed to say "I don't know", and I will ask for help when I am stuck.
-
-I will respect the privacy of my users, for their information is not disclosed to me that the world may know.
-
-I will tread most carefully in matters of life or death. I will be humble and recognize that I will make mistakes.
-
-I will remember that I do not write code for computers, but for people.
-
-I will consider the possible consequences of my code and actions. I will respect the difficulties of both social and technical problems.
-
-I will be diligent and take pride in my work.
-
-I will recognize that I can and will be wrong, sometimes. I will keep an open mind, and listen to others carefully and with respect.
-
-
+The Programmer's Oath
 ------
 
-Something missing? Disagree with a tenet? Think the wording should be changed? Please [open an issue](https://github.com/Widdershin/programmers-oath/issues/new) and we can figure it out. I highly welcome collaboration, and I will do my best to faciliate an oath that reflects a diverse range of views.
+This project aims to create an oath of moral conduct for programmers, inspired by the [Modern Hippocratic Oath](https://en.wikipedia.org/wiki/Hippocratic_Oath#Modern_version) and [the Obligation of the Engineer](https://en.wikipedia.org/wiki/Engineer's_Ring#The_Obligation_of_The_Engineer).
 
-Inspired by the [Modern Hippocratic Oath](https://en.wikipedia.org/wiki/Hippocratic_Oath#Modern_version) and [the Obligation of the Engineer](https://en.wikipedia.org/wiki/Engineer's_Ring#The_Obligation_of_The_Engineer).
+You can read the Programmer's Oath [here](TENETS.md).
+
+***************
+
+Something missing? Disagree with a tenet? Think the wording should be changed? Please [open an issue](https://github.com/Widdershin/programmers-oath/issues/new) and we can figure it out. I highly welcome collaboration, and I will do my best to faciliate an oath that reflects a diverse range of views.
 
 This is a very early draft. My intention is to collaboratively write an oath that could be spread in my community. I think the importance of considering the impact of our actions as coders is huge, and not talked about enough.
 

--- a/TENETS.md
+++ b/TENETS.md
@@ -1,0 +1,23 @@
+# Programmer's Oath
+
+**As a programmer, I swear to fulfill these tenets:**
+
+I will only undertake honest and moral work. I will stand firm against any requirement that exploits or harms people.
+
+I will respect the learnings of those programmers who came before me, and share my learnings with those to come.
+
+I will remember that programming is art as well as science, and that warmth, empathy and understanding may outweigh a clever algorithm or technical argument.
+
+I will not be ashamed to say "I don't know", and I will ask for help when I am stuck.
+
+I will respect the privacy of my users, for their information is not disclosed to me that the world may know.
+
+I will tread most carefully in matters of life or death. I will be humble and recognize that I will make mistakes.
+
+I will remember that I do not write code for computers, but for people.
+
+I will consider the possible consequences of my code and actions. I will respect the difficulties of both social and technical problems.
+
+I will be diligent and take pride in my work.
+
+I will recognize that I can and will be wrong, sometimes. I will keep an open mind, and listen to others carefully and with respect.


### PR DESCRIPTION
Fixes #9 by creating a separate file, [TENETS.md](TENETS.md) and cleaning up the README to point to it properly.