### PR TITLE
Remove a weasel word

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 8. I will be diligent and take pride in my work.
 
-9. I will recognize that I can and will be wrong, sometimes. I will keep an open mind, and listen to others carefully and with respect.
+9. I will recognize that I can and will be wrong. I will keep an open mind, and listen to others carefully and with respect.
 
 
 ------


### PR DESCRIPTION
A weasel word […] is an informal term for words and phrases aimed at creating an impression that a specific or meaningful statement has been made, when instead only a vague or ambiguous claim has actually been communicated. This can enable the speaker to later deny the specific meaning if the statement is challenged.

via https://en.wikipedia.org/wiki/Weasel_word