### PR TITLE
Add related work section (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The [Center for Humane Technology](https://humanetech.com) (CHT) community - who
 ## Related work
 
 - [Ethical Design Manifesto](https://2017.ind.ie/ethical-design/)
+- [Never Again Pledge](https://neveragain.tech/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The [Center for Humane Technology](https://humanetech.com) (CHT) community - who
 ## Related work
 
 - [Ethical Design Manifesto](https://2017.ind.ie/ethical-design/)
+- [Ethical OS Toolkit](https://ethicalos.org/)
 - [Never Again Pledge](https://neveragain.tech/)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The [Center for Humane Technology](https://humanetech.com) (CHT) community - who
 
 - [Ethical Design Manifesto](https://2017.ind.ie/ethical-design/)
 - [Ethical OS Toolkit](https://ethicalos.org/)
+- [ACM Code of Ethics](https://ethics.acm.org/)
 - [Never Again Pledge](https://neveragain.tech/)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ To do this, open another Pull Request. On your signature line, replace the old c
 
 The [Center for Humane Technology](https://humanetech.com) (CHT) community - who strive to align technology to humanity's best interests - endorses this repository with the Humane Tech badge. Raising employee awareness within IT companies is one of the CHT's core pillars, and adhering to the Progammer's Oath is an excellent start to work towards this goal.
 
+## Related work
+
+- [Ethical Design Manifesto](https://2017.ind.ie/ethical-design/)
+
 ## License
 
 [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](LICENSE)


### PR DESCRIPTION
I added a new section for Related work with 3 entries. I currently did not add descriptions, because the repositories do not provide a good-enough summary text (at least the Ethical Design Manifesto is self-describing).

The Ethical OS Toolkit has a [cool article](https://librarianshipwreck.wordpress.com/2018/08/24/striving-to-minimize-technical-and-reputational-risks-ethical-os-and-silicon-valleys-guilty-conscience/) on it, where they mention the need for a Hippocratic Oath. You may want to contact these guys & girls. It was also discussed on Hacker News: https://news.ycombinator.com/item?id=17839823